### PR TITLE
feat: rethink default.json for modern Renovate (v43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,35 @@ Add the following to your `renovate.json` or `package.json` (under `"renovate"` 
 }
 ```
 
-## Migration from npm preset
+## What this config does
 
-If you were previously using `"extends": ["@mi11er"]`, you should migrate to the repository-based preset format as npm presets are now deprecated:
+### Base
 
-```json
-{
-  "extends": ["github>mi11er-net/renovate-config"]
-}
-```
+Extends `config:recommended` (Renovate's current standard preset), which includes the
+Dependency Dashboard, semantic commit prefixes, curated monorepo groupings, and
+crowd-sourced workarounds and package replacements.
+
+### Update behaviour
+
+| Setting               | Value             | Rationale                                                                                |
+| --------------------- | ----------------- | ---------------------------------------------------------------------------------------- |
+| `minimumReleaseAge`   | 3 days            | npm packages can be unpublished within 72 h; wait for stability before proposing updates |
+| `prHourlyLimit`       | 10                | Avoids notification floods while still moving quickly after initial onboarding           |
+| Peer dep strategy     | widen             | Keeps published packages (e.g. eslint-config) compatible with multiple peer versions     |
+| Lock file maintenance | weekly, automerge | Routine regeneration; low risk, no review needed                                         |
+| Stale PRs             | rebase            | Keeps open PRs up-to-date with base branch automatically                                 |
+| PR creation           | not-pending       | Waits for branch CI to pass/fail before opening the PR                                   |
+
+### Package rules
+
+| Scope                              | Behaviour                                              |
+| ---------------------------------- | ------------------------------------------------------ |
+| npm devDependencies — minor/patch  | Grouped into one PR, automerges when CI passes         |
+| npm devDependencies — major        | Individual PRs, manual merge                           |
+| npm dependencies (non-dev)         | Renovate defaults — individual PRs, no automerge       |
+| GitHub Actions — digest updates    | Automerge (SHA pin refresh, no behaviour change)       |
+| GitHub Actions — version bumps     | Grouped as "GitHub Actions", manual merge              |
+| Docker — digest updates            | Automerge (image rebuild, no version change)           |
+| Docker — minor/patch version bumps | Grouped as "Docker images", manual merge               |
+| NuGet — minor/patch                | Grouped as "NuGet packages", automerges when CI passes |
+| CircleCI                           | Ungrouped, automerge, scheduled Monday before 6 am     |

--- a/default.json
+++ b/default.json
@@ -1,29 +1,73 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    ":dependencyDashboard",
-    ":maintainLockFilesWeekly",
+    "config:recommended",
     ":widenPeerDependencies",
-    ":prHourlyLimit4",
+    ":maintainLockFilesWeekly",
     ":rebaseStalePrs",
     ":prNotPending"
   ],
+  "prHourlyLimit": 10,
   "lockFileMaintenance": {
     "automerge": true
   },
   "packageRules": [
     {
-      "matchCategories": ["js"],
-      "matchPackagePatterns": ["*"],
-      "groupName": "All Dev",
-      "matchDepTypes": ["devDependencies"]
+      "description": "Wait 3 days before proposing npm updates (72-hour unpublish window)",
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
     },
     {
+      "description": "Group and automerge minor/patch npm devDependency updates",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "dev dependencies",
+      "automerge": true
+    },
+    {
+      "description": "Major devDependency updates: individual PRs, no automerge",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["major"],
+      "groupName": null,
+      "automerge": false
+    },
+    {
+      "description": "Automerge CircleCI image/orb updates on Monday mornings",
       "matchManagers": ["circleci"],
       "groupName": null,
       "automerge": true,
-      "schedule": "before 6am on Monday"
+      "schedule": ["before 6am on Monday"]
+    },
+    {
+      "description": "Automerge GitHub Actions digest updates (SHA pin refresh, no behavior change)",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest"],
+      "automerge": true
+    },
+    {
+      "description": "Group GitHub Actions version bumps for manual review",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "GitHub Actions"
+    },
+    {
+      "description": "Automerge Docker digest updates (image rebuild, no version change)",
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["digest"],
+      "automerge": true
+    },
+    {
+      "description": "Group Docker image minor/patch version bumps for manual review",
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Docker images"
+    },
+    {
+      "description": "Group and automerge NuGet minor/patch updates",
+      "matchManagers": ["nuget"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "NuGet packages",
+      "automerge": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "sort-package-json": "sort-package-json",
     "pretest": "run-s lint",
     "test": "run-s validate",
-    "validate": "renovate-config-validator"
+    "validate": "renovate-config-validator default.json"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Closes #350

## Summary

- **`config:recommended`** replaces deprecated `config:base`; removes explicit `:dependencyDashboard` (now included)
- **`minimumReleaseAge: "3 days"`** — prevents chasing packages unpublished within the npm 72-hour window
- **`prHourlyLimit: 10`** — up from 4, handles more managers without stalling
- **devDependency automerge** — minor/patch grouped + automerge when CI passes; majors get individual PRs
- **GitHub Actions** — digest updates automerge; version bumps grouped for manual review
- **Docker** — same split as GitHub Actions
- **NuGet** — minor/patch grouped + automerge
- **CircleCI** — Monday morning automerge rule retained
- **`validate` script** — now explicitly targets `default.json` (was only validating `package.json > renovate`)
- **README** — full behaviour table documents every rule and its rationale

## Test plan

- [ ] `npm test` passes (lint + `renovate-config-validator default.json`)
- [ ] GitHub Actions CI passes